### PR TITLE
Update the renewables data based on 2021-4-25 api dump

### DIFF
--- a/clock/climateclock.py
+++ b/clock/climateclock.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import math
 import os
 import sys
 import time
@@ -18,9 +17,9 @@ SECONDS_PER_YEAR = 365.25 * 24 * 3600
 # Snapshot of API data (the Good Stuff™)
 CARBON_DEADLINE_1 = datetime.fromisoformat("2028-01-01T12:00:00+00:00")
 RENEWABLES_1 = {
-    "initial": 26.2,
-    "timestamp": datetime.fromisoformat("2019-01-01T00:00:00+00:00"),
-    "rate": 2.8368383376368776e-8,
+    "initial": 11.4,
+    "timestamp": datetime.fromisoformat("2020-01-01T00:00:00+00:00"),
+    "rate": 2.0428359571070087e-08,
 }
 
 


### PR DESCRIPTION
The [api](https://api.climateclock.world/v1/clock) has an initial renewables value of 11.4 and starts on Jan 1, 2020. The python starts at 26.2 on Jan 1, 2019. Pretty wildly different values stood out to me. This updates the python to reflect the web api.

It also removes an unused math import because my lint complained about it. Seemed reasonable.

I haven't yet tossed this on a device since I haven't tackled the build process yet, but I'm happy to do that if needed.